### PR TITLE
Make product preview cards link to Bol.com listings

### DIFF
--- a/index.html
+++ b/index.html
@@ -226,6 +226,7 @@
         }
 
         .product-card {
+            display: block;
             background: #ffffff;
             border-radius: 20px;
             padding: 2rem;
@@ -233,6 +234,8 @@
             box-shadow: 0 10px 30px rgba(0,0,0,0.1);
             transition: transform 0.3s ease, box-shadow 0.3s ease;
             border: 2px solid transparent;
+            color: inherit;
+            text-decoration: none;
         }
 
         .product-card:hover {
@@ -652,24 +655,24 @@
             <div class="container">
                 <h2 class="section-title">Our natural food wraps</h2>
                 <div class="products-grid">
-                    <div class="product-card">
+                    <a href="https://www.bol.com/nl/nl/p/wrapz-bijenwas-wrap-herbruikbaar-boterhamzakje-herbruikbaar-folie-herbruikbare-afdekdoek-bijenwas-doeken-beeswax-wrap-bijenwasdoek-design-pink-flow/9300000238630950/?cid=1759415265743-9093086157527&bltgh=ba84d79a-5665-44cf-9c7c-cacbb97ca981.ProductList_Middle.1.ProductTitle" target="_blank" rel="noopener noreferrer" class="product-card">
                         <div class="product-image orange-wrap"></div>
                         <h3>Pink flow</h3>
                         <p>Soft pink design with elegant flow patterns. Perfect for covering bowls and wrapping fruits</p>
                         <div class="price">€11.00</div>
-                    </div>
-                    <div class="product-card">
+                    </a>
+                    <a href="https://www.bol.com/nl/nl/p/wrapz-bijenwas-wrap-herbruikbaar-boterhamzakje-herbruikbaar-folie-herbruikbare-afdekdoek-bijenwas-doeken-beeswax-wrap-bijenwasdoek-design-cherry-on-top/9300000238048771/?cid=1759415238723-7796839218924&bltgh=ba84d79a-5665-44cf-9c7c-cacbb97ca981.ProductList_Middle.0.ProductTitle" target="_blank" rel="noopener noreferrer" class="product-card">
                         <div class="product-image cherry-wrap"></div>
                         <h3>Cherry on top</h3>
                         <p>Playful cherry design on sunny yellow background. Fun and functional for kids' lunches</p>
                         <div class="price">€11.00</div>
-                    </div>
-                    <div class="product-card">
+                    </a>
+                    <a href="https://www.bol.com/nl/nl/p/wrapz-bijenwas-wrap-herbruikbaar-boterhamzakje-herbruikbaar-folie-herbruikbare-afdekdoek-bijenwas-doeken-beeswax-wrap-bijenwasdoek-design-bee-on-a-mission/9300000238630970/?cid=1759415284693-4503408784080&bltgh=ba84d79a-5665-44cf-9c7c-cacbb97ca981.ProductList_Middle.2.ProductTitle" target="_blank" rel="noopener noreferrer" class="product-card">
                         <div class="product-image bee-wrap"></div>
                         <h3>Bee on a mission</h3>
                         <p>Our signature bee pattern celebrating the natural source of our beeswax coating</p>
                         <div class="price">€11.00</div>
-                    </div>
+                    </a>
                 </div>
             </div>
         </section>


### PR DESCRIPTION
## Summary
- make each product preview card in the home page preview grid link directly to its Bol.com listing
- adjust the product card styling so the anchor-based cards keep their original appearance

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dec20d32508329a9dab389b940dd62